### PR TITLE
Fix `publishConfig` for hast-split-pre-lines

### DIFF
--- a/packages/hast-split-pre-lines/package.json
+++ b/packages/hast-split-pre-lines/package.json
@@ -36,7 +36,8 @@
         "import": "./lib/index.js",
         "types": "./lib/index.d.ts"
       }
-    }
+    },
+    "access": "public"
   },
   "dependencies": {
     "hast-util-from-parse5": "^8.0.3",


### PR DESCRIPTION
Should fix
<https://github.com/shivjm/remark-extensions/actions/runs/17774441495/job/50518480991#step:6:64>.